### PR TITLE
Update caldav process to caldav 0.4.0 method

### DIFF
--- a/pyvac/helpers/calendar.py
+++ b/pyvac/helpers/calendar.py
@@ -20,7 +20,7 @@ END:VCALENDAR
 """
 
     client = caldav.DAVClient(url)
-    principal = caldav.Principal(client, url)
+    principal = client.principal()
     calendars = principal.calendars()
     if not len(calendars):
         return False


### PR DESCRIPTION


There seems to be an error in the caldav upload process, tests with sabredav caldav implementations gave errors like this one:

[2016-02-04 11:18:32,166: ERROR/Worker-1] Error while adding to calendar
Traceback (most recent call last):
File "/opt/pyvac/pyvac/task/worker.py", line 243, in process
req.summarycal)
File "/opt/pyvac/pyvac/helpers/calendar.py", line 24, in addToCal
calendars = principal.calendars()
File "/opt/pyvac/venv/local/lib/python2.7/site-packages/caldav-0.4.0-py2.7.egg/caldav/objects.py", line 345, in calendars
return self.calendar_home_set.calendars()
File "/opt/pyvac/venv/local/lib/python2.7/site-packages/caldav-0.4.0-py2.7.egg/caldav/objects.py", line 326, in calendar_home_set
chs = self.get_properties([cdav.CalendarHomeSet()])
File "/opt/pyvac/venv/local/lib/python2.7/site-packages/caldav-0.4.0-py2.7.egg/caldav/objects.py", line 182, in get_properties
raise Exception("The CalDAV server you are using has "
Exception: The CalDAV server you are using has a problem with path handling.

The caldav module exemple i found where working however, the main difference where on the "principal" object creation:
"principal = caldav.Principal(client, url)" versus
"principal = caldav.Principal(client)" (working)

While reading the doc it also appeared the "latest" way was a simple method call from client object:
principal = client.principal()

Which also seem to work fine.
